### PR TITLE
chore: FUNDING.yml + gitignore nested repos

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,3 @@
+github: jagmarques
+custom:
+  - https://asqav.com

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+
+# local caches + nested repos
+crewAI/
+.gstack/
+dist/
+__pycache__/
+src/asqav_mcp/__pycache__/


### PR DESCRIPTION
Adds FUNDING.yml (github sponsor + custom asqav.com link). Ignores crewAI/, .gstack/, dist/, __pycache__/ which were polluting git status.