### PR TITLE
security: use support@asqav.com (security@ alias does not exist)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,7 +2,7 @@
 
 ## Reporting Vulnerabilities
 
-Email security@asqav.com with details. We will respond within 48 hours.
+Email support@asqav.com with details. We will respond within 48 hours.
 
 Do not open public issues for security vulnerabilities.
 


### PR DESCRIPTION
Only support@asqav.com and the personal owner address are configured. security@asqav.com bounces.